### PR TITLE
Update python-dateutil version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ tensorflow>=1.14.0,<2.0.0
 tensorflow_hub>=0.4.0
 scikit-learn>=0.20.0,<0.21; python_version < '3'
 scikit-learn>=0.20.0; python_version >= '3'
-python-dateutil>=2.7.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ tensorflow>=1.14.0,<2.0.0
 tensorflow_hub>=0.4.0
 scikit-learn>=0.20.0,<0.21; python_version < '3'
 scikit-learn>=0.20.0; python_version >= '3'
-python-dateutil>=2.6.1,<2.8.1
+python-dateutil>=2.7.3


### PR DESCRIPTION
- installing `featuretools[complete]` shows the following error:
```
ERROR: nlp-primitives 0.2.4 has requirement python-dateutil<2.8.1,>=2.6.1, but you'll have python-dateutil 2.8.1 which is incompatible.
```
- This attempts to resolve this by increasing the version required (matches the python version)