### PR TITLE
Fix install error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.13.3
 pandas>=0.23.0
+tensorflow>=1.14.0
 featuretools>=0.7.0
 nltk>=3.4.5
-tensorflow>=1.14.0
 tensorflow_hub>=0.4.0
 scikit-learn>=0.20.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 flake8>=3.7.0
 autopep8>=1.4.3
-isort<=5.0.0
+isort<5.0.0
 pytest>=4.4.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
 flake8>=3.7.0
 autopep8>=1.4.3
-isort>=4.3.4
+isort<=5.0.0
 pytest>=4.4.1


### PR DESCRIPTION
Need to list tensorflow above featuretools due to both requiring scipy and quirks of install order with pip

Pinning isort temporarily since the 5.x release is causing errors in the lint tests, making a separate PR for that