### PR TITLE
Remove LSA online dependency

### DIFF
--- a/nlp_primitives/__init__.py
+++ b/nlp_primitives/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 __version__ = '0.3.1'
 from .diversity_score import DiversityScore
-from .lsa import LSA
+from .lsa import LSA, make_trainer
 from .mean_characters_per_word import MeanCharactersPerWord
 from .part_of_speech_count import PartOfSpeechCount
 from .polarity_score import PolarityScore

--- a/nlp_primitives/lsa.py
+++ b/nlp_primitives/lsa.py
@@ -33,9 +33,9 @@ class LSA(TransformPrimitive):
         >>> res
         [[0.0, 0.0, 0.01], [0.0, 0.0, 0.0]]
 
-        Now, if we change the values of the input corpus, to something that better resembles
-        the given text, the same given input text will result in a different, more discerning,
-        output. Also, NaN values are handled, as well as strings without words.
+        Now, if we change the values of the input text to something that better resembles
+        the brown corpus, the result will be a different, more discerning output. 
+        Also, NaN values are handled, as well as strings without words.
 
         >>> lsa = LSA()
         >>> x = ["the earth is round", "", np.NaN, ".,/"]
@@ -43,6 +43,18 @@ class LSA(TransformPrimitive):
         >>> for i in range(len(res)): res[i] = [abs(round(x, 2)) for x in res[i]]
         >>> res
         [[0.01, 0.0, nan, 0.0], [0.0, 0.0, nan, 0.0]]
+
+        If we would rather use a custom corpus, we can use the `make_trainer` function first,
+        resulting in a different output for the same input text.
+
+        >>> corpus = ['she will help eat food for a long time', 'I like to walk', 'We go for long walks together']
+        >>> trainer = make_trainer(corpus)
+        >>> lsa = LSA(trainer=trainer)
+        >>> x = ["he helped her walk,", "me me me eat food", "the sentence doth long"]
+        >>> res = lsa(x).tolist()
+        >>> for i in range(len(res)): res[i] = [abs(round(x, 2)) for x in res[i]]
+        >>> res
+        [[0.0, 0.34, 0.4], [0.58, 0.0, 0.0]]
 
     """
     name = "lsa"
@@ -106,6 +118,15 @@ def _validate_trainer(trainer):
 
 
 def make_trainer(corpus, random_state=42):
+    """ Fits an LSA pipeline with the given corpus which can be used in an LSA primitive
+
+    Arguments:
+        corpus (list): A corpus to fit the pipeline with, as a one-dimensional list of strings.
+        random_state (int): The random state to seed the TruncatedSVD part of the pipeline with.
+
+    Returns:
+        A fitted LSA pipeline object
+    """
     trainer = make_pipeline(TfidfVectorizer(), TruncatedSVD(random_state=random_state))
     trainer.fit(corpus)
     return trainer

--- a/nlp_primitives/lsa.py
+++ b/nlp_primitives/lsa.py
@@ -46,11 +46,12 @@ class LSA(TransformPrimitive):
     return_type = Numeric
     default_value = 0
 
-    def __init__(self):
+    def __init__(self, random_state=42):
         self.number_output_features = 2
         self.n = 2
+        self.random_state = random_state
 
-        self.trainer = make_pipeline(TfidfVectorizer(), TruncatedSVD(random_state=42))
+        self.trainer = make_pipeline(TfidfVectorizer(), TruncatedSVD(random_state=random_state))
 
     def get_function(self):
         dtk = TreebankWordDetokenizer()
@@ -61,7 +62,7 @@ class LSA(TransformPrimitive):
             copy = copy.apply(lambda x: dtk.detokenize(clean_tokens(x)))
 
             fit_data = copy.tolist()
-            # TruncatedSVD cannot produce two features without two input values
+            # TruncatedSVD cannot produce two features without multiple input values
             if len(fit_data) == 1:
                 fit_data = fit_data * 2
             self.trainer.fit(fit_data)

--- a/nlp_primitives/tests/test_lsa.py
+++ b/nlp_primitives/tests/test_lsa.py
@@ -2,8 +2,11 @@ import pytest
 
 import numpy as np
 import pandas as pd
+from sklearn.decomposition import TruncatedSVD
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.pipeline import make_pipeline, Pipeline
 
-from ..lsa import LSA
+from ..lsa import LSA, make_trainer
 from ..utils import PrimitiveT, find_applicable_primitives, valid_dfs
 
 
@@ -17,9 +20,11 @@ class TestLSA(PrimitiveT):
                        'Hello'])
         primitive_func = self.primitive().get_function()
 
-        answers = np.array([[0.7751553, 0.7751553, 0., 0.], [0., 0., 1., 0.]])
+        answers = np.array(
+            [[0.06130623793383833, 0.01745556451033845, 0.0057337659660533094, 0.0002763538434776728],
+             [-0.04373122671005984, 0.04859242528049181, 0.01643423390395579, 0.0011141016579207792]])
         results = np.array(primitive_func(x).values.tolist())
-        np.testing.assert_array_almost_equal(answers, results)
+        np.testing.assert_array_almost_equal(answers, results, decimal=4)
 
     def test_nan(self):
         x = pd.Series([np.nan,
@@ -28,24 +33,43 @@ class TestLSA(PrimitiveT):
         primitive_func = self.primitive().get_function()
 
         answers = np.array(
-            [[np.nan, 0, 1],
-             [np.nan, 0, 0]])
+            [[np.nan, 0, 0.073817],
+             [np.nan, 0, -0.023258]])
         results = np.array(primitive_func(x).values.tolist())
-        np.testing.assert_array_almost_equal(answers, results)
+        np.testing.assert_array_almost_equal(answers, results, decimal=4)
 
     def test_one_string(self):
         primitive_func = self.primitive().get_function()
 
         x = pd.Series([np.nan])
-        with pytest.raises(ValueError, match='empty vocabulary'):
+        with pytest.raises(ValueError, match='Found array with 0'):
             primitive_func(x)
 
         x = pd.Series(['just one string in this example',])
         answers = np.array(
-            [[1.],
-             [0.]])
+            [[ 0.026843],
+             [-0.001465]])
         results = np.array(primitive_func(x).values.tolist())
         np.testing.assert_array_almost_equal(answers, results)
+
+    def test_invalid_trainer(self):
+        with pytest.raises(ValueError, match='not a Pipeline object'):
+            LSA(trainer=TruncatedSVD())
+        with pytest.raises(ValueError, match='incorrect number of transformers'):
+            LSA(trainer=make_pipeline(TruncatedSVD()))
+        with pytest.raises(ValueError, match='have a TfIdfVectorizer as its first transformer'):
+            LSA(trainer=make_pipeline(TruncatedSVD(), TruncatedSVD()))
+        with pytest.raises(ValueError, match='have a TruncatedSVD as its second transformer'):
+            LSA(trainer=make_pipeline(TfidfVectorizer(), TfidfVectorizer()))
+        with pytest.raises(ValueError, match='should be pre-fitted'):
+            LSA(trainer=make_pipeline(TfidfVectorizer(), TruncatedSVD()))
+
+    def test_valid_trainer(self, es):
+        corpus = ['this is a very small corpus', 'that will be able to be trained nonetheless']
+        transform, aggregation = find_applicable_primitives(self.primitive)
+        primitive_instance = LSA(trainer=make_trainer(corpus))
+        transform.append(primitive_instance)
+        valid_dfs(es, aggregation, transform, self.primitive.name.upper(), multi_output=True)
 
     def test_with_featuretools(self, es):
         transform, aggregation = find_applicable_primitives(self.primitive)

--- a/nlp_primitives/tests/test_lsa.py
+++ b/nlp_primitives/tests/test_lsa.py
@@ -1,3 +1,5 @@
+import pytest
+
 import numpy as np
 import pandas as pd
 
@@ -28,6 +30,20 @@ class TestLSA(PrimitiveT):
         answers = np.array(
             [[np.nan, 0, 1],
              [np.nan, 0, 0]])
+        results = np.array(primitive_func(x).values.tolist())
+        np.testing.assert_array_almost_equal(answers, results)
+
+    def test_one_string(self):
+        primitive_func = self.primitive().get_function()
+
+        x = pd.Series([np.nan])
+        with pytest.raises(ValueError, match='empty vocabulary'):
+            primitive_func(x)
+
+        x = pd.Series(['just one string in this example',])
+        answers = np.array(
+            [[1.],
+             [0.]])
         results = np.array(primitive_func(x).values.tolist())
         np.testing.assert_array_almost_equal(answers, results)
 

--- a/nlp_primitives/tests/test_lsa.py
+++ b/nlp_primitives/tests/test_lsa.py
@@ -15,13 +15,9 @@ class TestLSA(PrimitiveT):
                        'Hello'])
         primitive_func = self.primitive().get_function()
 
-        answers = pd.Series(
-            [[0.06130623793383833, 0.01745556451033845, 0.0057337659660533094, 0.0002763538434776728],
-             [-0.04393122671005984, 0.04819242528049181, 0.01643423390395579, 0.0011141016579207792]])
-        results = primitive_func(x)
-        np.testing.assert_array_almost_equal(np.concatenate(([np.array(answers[0])], [np.array(answers[1])]), axis=0),
-                                             np.concatenate(([np.array(results[0])], [np.array(results[1])]), axis=0),
-                                             decimal=2)
+        answers = np.array([[0.7751553, 0.7751553, 0., 0.], [0., 0., 1., 0.]])
+        results = np.array(primitive_func(x).values.tolist())
+        np.testing.assert_array_almost_equal(answers, results)
 
     def test_nan(self):
         x = pd.Series([np.nan,
@@ -29,13 +25,11 @@ class TestLSA(PrimitiveT):
                        'This IS a STRING.'])
         primitive_func = self.primitive().get_function()
 
-        answers = pd.Series(
-            [[np.nan, 0, 0.074],
-             [np.nan, 0, -0.024]])
-        results = primitive_func(x)
-        np.testing.assert_array_almost_equal(np.concatenate(([np.array(answers[0])], [np.array(answers[1])]), axis=0),
-                                             np.concatenate(([np.array(results[0])], [np.array(results[1])]), axis=0),
-                                             decimal=2)
+        answers = np.array(
+            [[np.nan, 0, 1],
+             [np.nan, 0, 0]])
+        results = np.array(primitive_func(x).values.tolist())
+        np.testing.assert_array_almost_equal(answers, results)
 
     def test_with_featuretools(self, es):
         transform, aggregation = find_applicable_primitives(self.primitive)


### PR DESCRIPTION
As per the discussion [here](https://github.com/FeatureLabs/nlp_primitives/pull/21), the previous behavior of the LSA primitive to use a pipeline fitted on nltk's brown corpus is maintained, but there is now the ability to pass in a pre-fitted trainer object to the primitive instead.

The decision to require the trainer to be pre-fitted stems from the requirement of all featuretools primitives to have every parameter passed into the primitive's constructor be saved as a class attribute. If a corpus was passed in here, it would be saved unnecessarily within the primitive. Therefore, while there is now a function to train a LSA pipeline given a corpus, it does not happen in the init function so as to keep memory requirements lower. 