### PR TITLE
v1.0.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,8 +3,10 @@ Changelog
 =========
 **v1.0.0** Aug 12, 2020
     * Changes
-        * Remove tensorflow and tensorhub as core requirements but instead 
-        can be installed with ``pip install nlp_primitives[complete]"`` (:pr:`24`)
+        * Remove tensorflow and tensorhub as core requirements, but they 
+        can be installed with ``pip install nlp_primitives[complete]``. The 
+        ``UniversalSentenceEncoder`` primitive requires the ``nlp_primitives[complete]``
+        install but all other primitives work with the standard install. (:pr:`24`)
     * Testing Changes
         * Update CircleCI to perform complete install and use matrix jobs (:pr:`24`)
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -1,9 +1,15 @@
 =========
 Changelog
 =========
-**Future Release**
-    * Remove tensorflow and tensorhub as core requirements but instead 
-      can be installed with ``pip install nlp_primitives[complete]"``
+**v1.0.0** Aug 12, 2020
+    * Changes
+        * Remove tensorflow and tensorhub as core requirements but instead 
+        can be installed with ``pip install nlp_primitives[complete]"`` (:pr:`24`)
+    * Testing Changes
+        * Update CircleCI to perform complete install and use matrix jobs (:pr:`24`)
+
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
 
 **v0.3.1**
     * Fix installation error related to scipy version

--- a/nlp_primitives/__init__.py
+++ b/nlp_primitives/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-__version__ = '0.3.1'
+__version__ = '1.0.0'
 from .diversity_score import DiversityScore
 from .lsa import LSA
 from .mean_characters_per_word import MeanCharactersPerWord

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras_require = {
 
 setup(
     name='nlp_primitives',
-    version='0.3.1',
+    version='1.0.0',
     author='Feature Labs, Inc.',
     author_email='support@featurelabs.com',
     license='BSD 3-clause',


### PR DESCRIPTION
**v1.0.0 Aug 12, 2020**
* Changes
    * Remove tensorflow and tensorhub as core requirements, but they can be installed with `pip install nlp_primitives[complete]`. The `UniversalSentenceEncoder` primitive requires the `nlp_primitives[complete]` install but all other primitives work with the standard install. (#24)
* Testing Changes
     * Update CircleCI to perform complete install and use matrix jobs (#24)