### PR TITLE
Refactor `clean_tokens` function

### DIFF
--- a/nlp_primitives/polarity_score.py
+++ b/nlp_primitives/polarity_score.py
@@ -4,7 +4,6 @@ import pandas as pd
 from featuretools.primitives.base import TransformPrimitive
 from featuretools.variable_types import Numeric, Text
 from nltk.sentiment.vader import SentimentIntensityAnalyzer
-from nltk.tokenize.treebank import TreebankWordDetokenizer
 
 from .utilities import clean_tokens
 
@@ -29,7 +28,6 @@ class PolarityScore(TransformPrimitive):
     default_value = 0
 
     def get_function(self):
-        dtk = TreebankWordDetokenizer()
 
         def polarity_score(x):
             try:
@@ -50,6 +48,6 @@ class PolarityScore(TransformPrimitive):
                     if len(el) < 1:
                         li.append(0.0)
                     else:
-                        li.append(vader_pol(dtk.detokenize(el)))
+                        li.append(vader_pol(str.join(' ', el)))
             return pd.Series(li)
         return polarity_score

--- a/nlp_primitives/tests/test_universal_sentence_encoder.py
+++ b/nlp_primitives/tests/test_universal_sentence_encoder.py
@@ -1,6 +1,7 @@
 import sys
 
 import featuretools as ft
+import numpy as np
 import pandas as pd
 import pytest
 from featuretools.primitives.utils import (
@@ -20,9 +21,9 @@ def test_regular(universal_sentence_encoder):
         "Mitochondria is the powerhouse of the cell",
     ])
     a = pd.DataFrame(universal_sentence_encoder(sentences))
-    a = a.mean().round(7).astype('str')
-    b = pd.Series(['-0.0007475', '0.0032088', '0.0018552', '0.0008256', '0.0028342'])
-    assert a.equals(b)
+    a = a.mean().round(7).to_numpy()
+    b = pd.Series([-0.0007475, 0.0032088, 0.0018552, 0.0008256, 0.0028342])
+    np.testing.assert_array_almost_equal(a, b)
 
 
 @pytest.fixture()
@@ -54,9 +55,9 @@ def test_primitive_serialization(universal_sentence_encoder):
     deserialized_primitive = deserializer.deserialize_primitive(serialized_primitive)
 
     a = pd.DataFrame(deserialized_primitive(sentences))
-    a = a.mean().round(7).astype('str')
-    b = pd.Series(['-0.0007475', '0.0032088', '0.0018552', '0.0008256', '0.0028342'])
-    assert a.equals(b)
+    a = a.mean().round(7).to_numpy()
+    b = np.array([-0.0007475, 0.0032088, 0.0018552, 0.0008256, 0.0028342])
+    np.testing.assert_array_almost_equal(a, b)
 
 
 def test_feature_serialization(universal_sentence_encoder, tmpdir):

--- a/nlp_primitives/utilities.py
+++ b/nlp_primitives/utilities.py
@@ -8,24 +8,25 @@ wn = nltk.WordNetLemmatizer()
 
 def clean_tokens(textstr):
     try:
+        textstr = nltk.tokenize.word_tokenize(textstr)
+    except LookupError:
+        nltk.download('punkt')
+        textstr = nltk.tokenize.word_tokenize(textstr)
+
+    try:
         swords = set(nltk.corpus.stopwords.words('english'))
+        textstr = [ch.lower() for ch in textstr if ch not in tset(string.punctuation).union(swords)]
     except LookupError:
         nltk.download('stopwords')
         swords = set(nltk.corpus.stopwords.words('english'))
+        textstr = [ch.lower() for ch in textstr if ch not in set(string.punctuation).union(swords)]
+
+    try:
+        textstr = [wn.lemmatize(w) for w in textstr]
+    except LookupError:
+        nltk.download('wordnet')
+        textstr = [wn.lemmatize(w) for w in textstr]
+
     finally:
-        try:
-            textstr = nltk.tokenize.word_tokenize(textstr)
-        except LookupError:
-            nltk.download('punkt')
-            textstr = nltk.tokenize.word_tokenize(textstr)
-        finally:
-            try:
-                wn.lemmatize("")
-            except LookupError:
-                nltk.download('wordnet')
-            finally:
-                processed = [ch.lower() for ch in textstr if ch not in
-                             set(string.punctuation).union(swords)]
-                processed = ['0' if re.search('[0-9]+', ch) else ch for ch in processed]
-                processed = [wn.lemmatize(w) for w in processed]
-                return processed
+        textstr = ['0' if re.search('[0-9]+', ch) else ch for ch in textstr]
+        return textstr

--- a/nlp_primitives/utilities.py
+++ b/nlp_primitives/utilities.py
@@ -7,19 +7,18 @@ wn = nltk.WordNetLemmatizer()
 
 
 def clean_tokens(textstr):
-    try:
-        textstr = nltk.tokenize.word_tokenize(textstr)
-    except LookupError:
-        nltk.download('punkt')
-        textstr = nltk.tokenize.word_tokenize(textstr)
+    textstr = textstr.translate(str.maketrans('', '', string.punctuation))
+    textstr = [ch for ch in textstr.split(' ') if len(ch)>0]
 
     try:
         swords = set(nltk.corpus.stopwords.words('english'))
-        textstr = [ch.lower() for ch in textstr if ch not in tset(string.punctuation).union(swords)]
+        to_remove = set(string.punctuation).union(swords)
+        textstr = [ch.lower() for ch in textstr if ch not in to_remove]
     except LookupError:
         nltk.download('stopwords')
         swords = set(nltk.corpus.stopwords.words('english'))
-        textstr = [ch.lower() for ch in textstr if ch not in set(string.punctuation).union(swords)]
+        to_remove = set(string.punctuation).union(swords)
+        textstr = [ch.lower() for ch in textstr if ch not in to_remove]
 
     try:
         textstr = [wn.lemmatize(w) for w in textstr]

--- a/nlp_primitives/utilities.py
+++ b/nlp_primitives/utilities.py
@@ -27,5 +27,5 @@ def clean_tokens(textstr):
         textstr = [wn.lemmatize(w) for w in textstr]
 
     finally:
-        textstr = ['0' if re.search('[0-9]+', ch) else ch for ch in textstr]
+        textstr = ['0' if any(map(str.isdigit, ch)) else ch for ch in textstr]
         return textstr

--- a/nlp_primitives/utilities.py
+++ b/nlp_primitives/utilities.py
@@ -1,4 +1,3 @@
-import re
 import string
 
 import nltk

--- a/nlp_primitives/utilities.py
+++ b/nlp_primitives/utilities.py
@@ -8,7 +8,7 @@ wn = nltk.WordNetLemmatizer()
 
 def clean_tokens(textstr):
     textstr = textstr.translate(str.maketrans('', '', string.punctuation))
-    textstr = [ch for ch in textstr.split(' ') if len(ch)>0]
+    textstr = [ch for ch in textstr.split(' ') if len(ch) > 0]
 
     try:
         swords = set(nltk.corpus.stopwords.words('english'))


### PR DESCRIPTION
- Fixes a few `universal_sentence_encoder` tests that were failing on master
- Refactors the try/except/finally logic in `clean_tokens` so that a download failing will skip that part and complete successfully rather than raising a `Variable referenced before assignment` error
- Removes the `nltk.word_tokenizer` in `clean_tokens` altogether in preference for an equivalent set of operations that takes half the time to run
- Removes the `nltk` detokenizer from `PolarityScore`, since the same operation can be performed by `str.join(' ')` in a much shorter amount of time

Running cProfile:
Original `clean_tokens` performance
![clean_tokens_original](https://user-images.githubusercontent.com/60074782/91891536-3399ff00-ec5f-11ea-8237-bc79d17be1eb.png)
After removing `word_tokenizer` 
![clean_tokens_union_out_of_listcomp](https://user-images.githubusercontent.com/60074782/91891586-4ad8ec80-ec5f-11ea-92ab-58796b1892fe.png)
