### PR TITLE
Unpack nltk data at install, not during sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include *.txt
 include LICENSE
 include README.md
-recursive-include nlp_primitives/data/nltk-data/ *
+include nlp_primitives/data/nltk-data.tar
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from os import path
 
 from setuptools import find_packages, setup
-from setuptools.command.sdist import sdist
+from setuptools.command.install import install
 
 import pathlib
 import pkg_resources
@@ -15,8 +15,8 @@ extras_require = {
     'complete': open('complete-requirements.txt').readlines()
 }
 
-class PreSDistNLTKDataUnpackCommand(sdist):
-    """Before creating source distribution, untar nltk data files, so they'll be included via the manifest file.
+class PreInstallNLTKDataUnpackCommand(install):
+    """During installation, untar nltk data files, so they'll be included via the manifest file.
 
     Note the usage of `pkg_resources.resource_filename` for pathing assumes you're building the source distribution with your cwd
     in the repo.
@@ -29,7 +29,7 @@ class PreSDistNLTKDataUnpackCommand(sdist):
         with tarfile.open(nltk_data_tarball_path, "r") as tar:
             tar.extractall(path=nltk_data_extract_path)
             print(f'Extraction of nltk data files complete')
-            sdist.run(self)
+            install.run(self)
 
 setup(
     name='nlp_primitives',
@@ -52,6 +52,6 @@ setup(
         ],
     },
     cmdclass={
-        'sdist': PreSDistNLTKDataUnpackCommand
+        'install': PreInstallNLTKDataUnpackCommand
     }
 )


### PR DESCRIPTION
#31 made it so that during `sdist` creation, nltk data files are unpacked from a tarfile. This PR updates that to happen during installation, instead of before `sdist` creation.

This means we'll ship the distribution with the tarfile included, not the untarred data files. This also means that we can do non-release installations and still have the nltk data be unpacked correctly.