### PR TITLE
Use authenticated docker pulls for Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,22 +132,22 @@ workflows:
       - lint_tests:
           matrix:
             parameters:
-              image_tag: ["3.6, 3.7, 3.8"]
+              image_tag: ["3.6", "3.7", "3.8"]
           name: << matrix.image_tag >> lint tests
       - unit_tests:
           matrix:
             parameters:
-              image_tag: ["3.6, 3.7, 3.8"]
+              image_tag: ["3.6", "3.7", "3.8"]
           name: << matrix.image_tag >> unit tests
   "Packaging Tests":
     jobs:
       - entry_point_test:
           matrix:
             parameters:
-              image_tag: ["3.6, 3.7, 3.8"]
+              image_tag: ["3.6", "3.7", "3.8"]
           name: << matrix.image_tag >> entry point test
       - package_test:
           matrix:
             parameters:
-              image_tag: ["3.6, 3.7, 3.8"]
+              image_tag: ["3.6", "3.7", "3.8"]
           name: << matrix.image_tag >> package tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ executors:
         type: string
         default: "python:3.8"
     docker:
-      - image: circleci/<< parameters.image_tag >>
+      - image: circleci/python:<< parameters.image_tag >>
     resource_class: large
 
 commands:
@@ -130,40 +130,24 @@ workflows:
   "Integration Tests":
     jobs:
       - lint_tests:
-          name: "Lint Tests - Python 3.6"
-          image_tag: "python:3.6"
-      - lint_tests:
-          name: "Lint Tests - Python 3.7"
-          image_tag: "python:3.7"
-      - lint_tests:
-          name: "Lint Tests - Python 3.8"
-          image_tag: "python:3.8"
+          matrix:
+            parameters:
+              image_tag: ["3.6, 3.7, 3.8"]
+          name: << matrix.image_tag >> lint tests
       - unit_tests:
-          name: "Unit Tests - Python 3.6"
-          image_tag: "python:3.6"
-      - unit_tests:
-          name: "Unit Tests - Python 3.7"
-          image_tag: "python:3.7"
-      - unit_tests:
-          name: "Unit Tests - Python 3.8"
-          image_tag: "python:3.8"
+          matrix:
+            parameters:
+              image_tag: ["3.6, 3.7, 3.8"]
+          name: << matrix.image_tag >> unit tests
   "Packaging Tests":
     jobs:
       - entry_point_test:
-          name: "Entry Point Test - Python 3.6"
-          image_tag: "python:3.6"
-      - entry_point_test:
-          name: "Entry Point Test - Python 3.7"
-          image_tag: "python:3.7"
-      - entry_point_test:
-          name: "Entry Point Test - Python 3.8"
-          image_tag: "python:3.8"
+          matrix:
+            parameters:
+              image_tag: ["3.6, 3.7, 3.8"]
+          name: << matrix.image_tag >> entry point test
       - package_test:
-          name: "Packaging Test - Python 3.6"
-          image_tag: "python:3.6"
-      - package_test:
-          name: "Packaging Test - Python 3.7"
-          image_tag: "python:3.7"
-      - package_test:
-          name: "Packaging Test - Python 3.8"
-          image_tag: "python:3.8"
+          matrix:
+            parameters:
+              image_tag: ["3.6, 3.7, 3.8"]
+          name: << matrix.image_tag >> package tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ executors:
         default: "python:3.8"
     docker:
       - image: circleci/python:<< parameters.image_tag >>
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     resource_class: large
 
 commands:
@@ -134,11 +137,13 @@ workflows:
             parameters:
               image_tag: ["3.6", "3.7", "3.8"]
           name: << matrix.image_tag >> lint tests
+          context: dockerhub
       - unit_tests:
           matrix:
             parameters:
               image_tag: ["3.6", "3.7", "3.8"]
           name: << matrix.image_tag >> unit tests
+          context: dockerhub
   "Packaging Tests":
     jobs:
       - entry_point_test:
@@ -146,8 +151,10 @@ workflows:
             parameters:
               image_tag: ["3.6", "3.7", "3.8"]
           name: << matrix.image_tag >> entry point test
+          context: dockerhub
       - package_test:
           matrix:
             parameters:
               image_tag: ["3.6", "3.7", "3.8"]
           name: << matrix.image_tag >> package tests
+          context: dockerhub


### PR DESCRIPTION
Update Circle CI config to use the job matrix format and authenticate with dockerhub